### PR TITLE
Add stub modules and basic test

### DIFF
--- a/k9-trainer/src/app/auth/login-page/login-page.component.spec.ts
+++ b/k9-trainer/src/app/auth/login-page/login-page.component.spec.ts
@@ -1,0 +1,34 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LoginPageComponent } from './login-page.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+
+describe('LoginPageComponent', () => {
+  let component: LoginPageComponent;
+  let fixture: ComponentFixture<LoginPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LoginPageComponent],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        MatCardModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatButtonModule
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/k9-trainer/src/app/calendar/calendar.module.ts
+++ b/k9-trainer/src/app/calendar/calendar.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { SessionsCalendarPageComponent } from './sessions-calendar-page.component';
+
+const routes: Routes = [
+  { path: '', component: SessionsCalendarPageComponent }
+];
+
+@NgModule({
+  declarations: [SessionsCalendarPageComponent],
+  imports: [CommonModule, RouterModule.forChild(routes)]
+})
+export class CalendarModule {}

--- a/k9-trainer/src/app/calendar/sessions-calendar-page.component.ts
+++ b/k9-trainer/src/app/calendar/sessions-calendar-page.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-sessions-calendar-page',
+  template: '<p>Calendar works!</p>'
+})
+export class SessionsCalendarPageComponent {}

--- a/k9-trainer/src/app/messaging/conversations-page.component.ts
+++ b/k9-trainer/src/app/messaging/conversations-page.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-conversations-page',
+  template: '<p>Messaging works!</p>'
+})
+export class ConversationsPageComponent {}

--- a/k9-trainer/src/app/messaging/messaging.module.ts
+++ b/k9-trainer/src/app/messaging/messaging.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { ConversationsPageComponent } from './conversations-page.component';
+
+const routes: Routes = [
+  { path: '', component: ConversationsPageComponent }
+];
+
+@NgModule({
+  declarations: [ConversationsPageComponent],
+  imports: [CommonModule, RouterModule.forChild(routes)]
+})
+export class MessagingModule {}


### PR DESCRIPTION
## Summary
- add Calendar and Messaging modules referenced in routes
- add basic Jest test for `LoginPageComponent`

## Testing
- `npm test` *(fails: ng not found)*
- `npx jest` *(fails: 403 Forbidden)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing jest type)*

------
https://chatgpt.com/codex/tasks/task_e_684c3d2bd3808327beb776272cc0c73f